### PR TITLE
add Atlassian Rovo MCP demo: getaccessibleatlassianresources

### DIFF
--- a/direct/atlassianmcp.py
+++ b/direct/atlassianmcp.py
@@ -1,0 +1,50 @@
+import scalekit.client
+import os
+import json
+from dotenv import load_dotenv
+
+# Load environment variables
+load_dotenv()
+
+scalekit = scalekit.client.ScalekitClient(
+    os.getenv("SCALEKIT_ENV_URL"),
+    os.getenv("SCALEKIT_CLIENT_ID"),
+    os.getenv("SCALEKIT_CLIENT_SECRET"),
+)
+connect = scalekit.connect
+
+connection_name = "atlassianmcp"
+identifier = "your_atlassian_user"
+
+# Step 1 — authorize the connection
+link_response = connect.get_authorization_link(
+    connection_name=connection_name,
+    identifier=identifier,
+)
+
+print("Click the link to authorize Atlassian Rovo MCP:", link_response.link)
+input("Press Enter after authorizing...")
+
+# Step 2 — get accessible Atlassian resources to retrieve the cloudId
+#
+# Most Atlassian Rovo MCP tools require a `cloudId` — the UUID that identifies
+# your Atlassian cloud site. Call this tool once and use the `id` field from
+# the response as the `cloudId` input in all subsequent tool calls.
+response = connect.execute_tool(
+    tool_name="atlassianmcp_getaccessibleatlassianresources",
+    identifier=identifier,
+    tool_input={},
+)
+
+resources = json.loads(response.data["content"][0]["text"])
+
+print("\nAccessible Atlassian resources:")
+for resource in resources:
+    print(f"  id   : {resource['id']}")
+    print(f"  name : {resource['name']}")
+    print(f"  url  : {resource['url']}")
+    print()
+
+# Use the first site's id as cloudId in subsequent calls
+cloud_id = resources[0]["id"]
+print(f"cloudId to use in subsequent tool calls: {cloud_id}")

--- a/proxy/tableau.py
+++ b/proxy/tableau.py
@@ -1,0 +1,129 @@
+"""
+Tableau export and download examples using the Scalekit proxy.
+
+Tableau's export endpoints (PDF, image, crosstab, CSV data) and download
+endpoints (workbook .twbx, datasource .tdsx) return binary file content.
+Use actions.request() to retrieve the bytes and save them locally.
+
+Run:
+    python tableau.py
+"""
+
+import os
+
+from dotenv import load_dotenv
+import scalekit.client as scalekit_sdk
+
+load_dotenv()
+
+ENV_URL = os.getenv("ENV_URL")
+CLIENT_ID = os.getenv("CLIENT_ID")
+CLIENT_SECRET = os.getenv("CLIENT_SECRET")
+
+# Your Tableau connection name from the Scalekit dashboard and your user identifier
+CONNECTION_NAME = "<YOUR_CONNECTION_NAME>"
+IDENTIFIER = "<YOUR_USER_IDENTIFIER>"
+
+# IDs — get these from the list/get tools (e.g. tableau_workbooks_list, tableau_views_list)
+SITE_ID = "<YOUR_SITE_ID>"
+WORKBOOK_ID = "<YOUR_WORKBOOK_ID>"
+VIEW_ID = "<YOUR_VIEW_ID>"
+DATASOURCE_ID = "<YOUR_DATASOURCE_ID>"
+
+
+def main():
+    client = scalekit_sdk.ScalekitClient(ENV_URL, CLIENT_ID, CLIENT_SECRET)
+    actions = client.actions
+
+    # ── Export view as PDF ────────────────────────────────────────────────────
+
+    print("Exporting view as PDF...")
+    pdf_response = actions.request(
+        connection_name=CONNECTION_NAME,
+        identifier=IDENTIFIER,
+        path=f"/api/3.28/sites/{SITE_ID}/views/{VIEW_ID}/pdf",
+        method="GET",
+        query_params={
+            "type": "A4",          # page size: Letter, Legal, A4, A5, B5
+            "orientation": "Landscape",  # Portrait or Landscape
+        },
+    )
+    with open("view_export.pdf", "wb") as f:
+        f.write(pdf_response.content)
+    print(f"PDF saved to: view_export.pdf ({len(pdf_response.content):,} bytes)")
+
+    # ── Export view as PNG image ──────────────────────────────────────────────
+
+    print("\nExporting view as image...")
+    image_response = actions.request(
+        connection_name=CONNECTION_NAME,
+        identifier=IDENTIFIER,
+        path=f"/api/3.28/sites/{SITE_ID}/views/{VIEW_ID}/image",
+        method="GET",
+        query_params={
+            "resolution": "high",  # high or standard
+        },
+    )
+    with open("view_export.png", "wb") as f:
+        f.write(image_response.content)
+    print(f"Image saved to: view_export.png ({len(image_response.content):,} bytes)")
+
+    # ── Export view crosstab as Excel ─────────────────────────────────────────
+
+    print("\nExporting view crosstab as Excel...")
+    crosstab_response = actions.request(
+        connection_name=CONNECTION_NAME,
+        identifier=IDENTIFIER,
+        path=f"/api/3.28/sites/{SITE_ID}/views/{VIEW_ID}/crosstab/excel",
+        method="GET",
+    )
+    with open("view_crosstab.xlsx", "wb") as f:
+        f.write(crosstab_response.content)
+    print(f"Crosstab saved to: view_crosstab.xlsx ({len(crosstab_response.content):,} bytes)")
+
+    # ── Export view data as CSV ───────────────────────────────────────────────
+
+    print("\nExporting view data as CSV...")
+    data_response = actions.request(
+        connection_name=CONNECTION_NAME,
+        identifier=IDENTIFIER,
+        path=f"/api/3.28/sites/{SITE_ID}/views/{VIEW_ID}/data",
+        method="GET",
+        query_params={
+            "pageSize": 200,
+            "pageNumber": 1,
+        },
+    )
+    with open("view_data.csv", "wb") as f:
+        f.write(data_response.content)
+    print(f"CSV saved to: view_data.csv ({len(data_response.content):,} bytes)")
+
+    # ── Download workbook (.twbx) ─────────────────────────────────────────────
+
+    print(f"\nDownloading workbook {WORKBOOK_ID}...")
+    workbook_response = actions.request(
+        connection_name=CONNECTION_NAME,
+        identifier=IDENTIFIER,
+        path=f"/api/3.28/sites/{SITE_ID}/workbooks/{WORKBOOK_ID}/content",
+        method="GET",
+    )
+    with open("workbook.twbx", "wb") as f:
+        f.write(workbook_response.content)
+    print(f"Workbook saved to: workbook.twbx ({len(workbook_response.content):,} bytes)")
+
+    # ── Download data source (.tdsx) ──────────────────────────────────────────
+
+    print(f"\nDownloading data source {DATASOURCE_ID}...")
+    datasource_response = actions.request(
+        connection_name=CONNECTION_NAME,
+        identifier=IDENTIFIER,
+        path=f"/api/3.28/sites/{SITE_ID}/datasources/{DATASOURCE_ID}/content",
+        method="GET",
+    )
+    with open("datasource.tdsx", "wb") as f:
+        f.write(datasource_response.content)
+    print(f"Data source saved to: datasource.tdsx ({len(datasource_response.content):,} bytes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/proxy/tableau.py
+++ b/proxy/tableau.py
@@ -1,9 +1,10 @@
 """
-Tableau export and download examples using the Scalekit proxy.
+Tableau proxy examples using the Scalekit proxy.
 
-Tableau's export endpoints (PDF, image, crosstab, CSV data) and download
-endpoints (workbook .twbx, datasource .tdsx) return binary file content.
-Use actions.request() to retrieve the bytes and save them locally.
+Tableau binary downloads (PNG, PDF, Excel, .twbx, .tdsx) must go through
+the Scalekit proxy — the session token (X-Tableau-Auth) is injected
+automatically. The site ID is resolved from the connected account after
+sign-in; call tableau_session_get once to retrieve it for URL construction.
 
 Run:
     python tableau.py
@@ -16,18 +17,18 @@ import scalekit.client as scalekit_sdk
 
 load_dotenv()
 
-ENV_URL = os.getenv("ENV_URL")
-CLIENT_ID = os.getenv("CLIENT_ID")
-CLIENT_SECRET = os.getenv("CLIENT_SECRET")
+ENV_URL = os.getenv("SCALEKIT_ENV_URL")
+CLIENT_ID = os.getenv("SCALEKIT_CLIENT_ID")
+CLIENT_SECRET = os.getenv("SCALEKIT_CLIENT_SECRET")
 
-# Your Tableau connection name from the Scalekit dashboard and your user identifier
+# Your Tableau connection name from the Scalekit dashboard and your user ID
 CONNECTION_NAME = "<YOUR_CONNECTION_NAME>"
 IDENTIFIER = "<YOUR_USER_IDENTIFIER>"
 
-# IDs — get these from the list/get tools (e.g. tableau_workbooks_list, tableau_views_list)
-SITE_ID = "<YOUR_SITE_ID>"
-WORKBOOK_ID = "<YOUR_WORKBOOK_ID>"
+# IDs to fill in before running — fetch these via tableau_workbooks_list
+# and tableau_views_list first (see comments below).
 VIEW_ID = "<YOUR_VIEW_ID>"
+WORKBOOK_ID = "<YOUR_WORKBOOK_ID>"
 DATASOURCE_ID = "<YOUR_DATASOURCE_ID>"
 
 
@@ -35,94 +36,118 @@ def main():
     client = scalekit_sdk.ScalekitClient(ENV_URL, CLIENT_ID, CLIENT_SECRET)
     actions = client.actions
 
-    # ── Export view as PDF ────────────────────────────────────────────────────
-
-    print("Exporting view as PDF...")
-    pdf_response = actions.request(
+    connected_account = actions.get_connected_account(
         connection_name=CONNECTION_NAME,
         identifier=IDENTIFIER,
-        path=f"/api/3.28/sites/{SITE_ID}/views/{VIEW_ID}/pdf",
-        method="GET",
-        query_params={
-            "type": "A4",          # page size: Letter, Legal, A4, A5, B5
-            "orientation": "Landscape",  # Portrait or Landscape
-        },
+    ).connected_account
+
+    # ── Get site ID ───────────────────────────────────────────────────────────
+    # The site ID (LUID) is needed to build proxy URL paths.
+    # Call tableau_session_get once and reuse the value for all requests.
+
+    session = actions.execute_tool(
+        tool_name="tableau_session_get",
+        connected_account_id=connected_account.id,
+        tool_input={},
     )
-    with open("view_export.pdf", "wb") as f:
-        f.write(pdf_response.content)
-    print(f"PDF saved to: view_export.pdf ({len(pdf_response.content):,} bytes)")
+    site_id = session.data["session"]["site"]["id"]
+    print(f"Site ID: {site_id}")
 
-    # ── Export view as PNG image ──────────────────────────────────────────────
+    # ── Discover IDs (optional — uncomment to find VIEW_ID / WORKBOOK_ID) ────
+    #
+    # workbooks = actions.execute_tool(
+    #     tool_name="tableau_workbooks_list",
+    #     connected_account_id=connected_account.id,
+    #     tool_input={},
+    # )
+    # for wb in workbooks["workbooks"]["workbook"]:
+    #     print(f"Workbook: {wb['id']}  {wb['name']}")
+    #
+    # views = actions.execute_tool(
+    #     tool_name="tableau_views_list",
+    #     connected_account_id=connected_account.id,
+    #     tool_input={},
+    # )
+    # for v in views["views"]["view"]:
+    #     print(f"View: {v['id']}  {v['name']}")
 
-    print("\nExporting view as image...")
+    # ── Export a view as PNG ──────────────────────────────────────────────────
+
+    print(f"\nExporting view {VIEW_ID} as PNG...")
+
     image_response = actions.request(
         connection_name=CONNECTION_NAME,
         identifier=IDENTIFIER,
-        path=f"/api/3.28/sites/{SITE_ID}/views/{VIEW_ID}/image",
+        path=f"/api/3.28/sites/{site_id}/views/{VIEW_ID}/image",
         method="GET",
-        query_params={
-            "resolution": "high",  # high or standard
-        },
+        query_params={"resolution": "high"},
     )
-    with open("view_export.png", "wb") as f:
+
+    if image_response.status_code != 200:
+        print(f"PNG export failed: {image_response.status_code} {image_response.text}")
+        return
+
+    with open("dashboard.png", "wb") as f:
         f.write(image_response.content)
-    print(f"Image saved to: view_export.png ({len(image_response.content):,} bytes)")
+    print(f"Saved dashboard.png ({len(image_response.content):,} bytes)")
 
-    # ── Export view crosstab as Excel ─────────────────────────────────────────
+    # ── Export a view as PDF ──────────────────────────────────────────────────
 
-    print("\nExporting view crosstab as Excel...")
-    crosstab_response = actions.request(
+    print(f"\nExporting view {VIEW_ID} as PDF...")
+
+    pdf_response = actions.request(
         connection_name=CONNECTION_NAME,
         identifier=IDENTIFIER,
-        path=f"/api/3.28/sites/{SITE_ID}/views/{VIEW_ID}/crosstab/excel",
+        path=f"/api/3.28/sites/{site_id}/views/{VIEW_ID}/pdf",
         method="GET",
+        query_params={"type": "a4", "orientation": "landscape"},
     )
-    with open("view_crosstab.xlsx", "wb") as f:
-        f.write(crosstab_response.content)
-    print(f"Crosstab saved to: view_crosstab.xlsx ({len(crosstab_response.content):,} bytes)")
 
-    # ── Export view data as CSV ───────────────────────────────────────────────
+    if pdf_response.status_code != 200:
+        print(f"PDF export failed: {pdf_response.status_code} {pdf_response.text}")
+        return
 
-    print("\nExporting view data as CSV...")
-    data_response = actions.request(
-        connection_name=CONNECTION_NAME,
-        identifier=IDENTIFIER,
-        path=f"/api/3.28/sites/{SITE_ID}/views/{VIEW_ID}/data",
-        method="GET",
-        query_params={
-            "pageSize": 200,
-            "pageNumber": 1,
-        },
-    )
-    with open("view_data.csv", "wb") as f:
-        f.write(data_response.content)
-    print(f"CSV saved to: view_data.csv ({len(data_response.content):,} bytes)")
+    with open("dashboard.pdf", "wb") as f:
+        f.write(pdf_response.content)
+    print(f"Saved dashboard.pdf ({len(pdf_response.content):,} bytes)")
 
-    # ── Download workbook (.twbx) ─────────────────────────────────────────────
+    # ── Download a workbook (.twbx) ───────────────────────────────────────────
 
     print(f"\nDownloading workbook {WORKBOOK_ID}...")
+
     workbook_response = actions.request(
         connection_name=CONNECTION_NAME,
         identifier=IDENTIFIER,
-        path=f"/api/3.28/sites/{SITE_ID}/workbooks/{WORKBOOK_ID}/content",
+        path=f"/api/3.28/sites/{site_id}/workbooks/{WORKBOOK_ID}/content",
         method="GET",
     )
+
+    if workbook_response.status_code != 200:
+        print(f"Workbook download failed: {workbook_response.status_code} {workbook_response.text}")
+        return
+
     with open("workbook.twbx", "wb") as f:
         f.write(workbook_response.content)
-    print(f"Workbook saved to: workbook.twbx ({len(workbook_response.content):,} bytes)")
+    print(f"Saved workbook.twbx ({len(workbook_response.content):,} bytes)")
 
-    # ── Download data source (.tdsx) ──────────────────────────────────────────
+    # ── Download a data source (.tdsx) ────────────────────────────────────────
 
     print(f"\nDownloading data source {DATASOURCE_ID}...")
+
     datasource_response = actions.request(
         connection_name=CONNECTION_NAME,
         identifier=IDENTIFIER,
-        path=f"/api/3.28/sites/{SITE_ID}/datasources/{DATASOURCE_ID}/content",
+        path=f"/api/3.28/sites/{site_id}/datasources/{DATASOURCE_ID}/content",
         method="GET",
     )
+
+    if datasource_response.status_code != 200:
+        print(f"Data source download failed: {datasource_response.status_code} {datasource_response.text}")
+        return
+
     with open("datasource.tdsx", "wb") as f:
         f.write(datasource_response.content)
-    print(f"Data source saved to: datasource.tdsx ({len(datasource_response.content):,} bytes)")
+    print(f"Saved datasource.tdsx ({len(datasource_response.content):,} bytes)")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a Python demo script for the Atlassian Rovo MCP connector.

- Authorizes the connection via `get_authorization_link`
- Calls `atlassianmcp_getaccessibleatlassianresources` to list accessible Atlassian cloud sites
- Extracts `cloudId` from the response — required as input for all subsequent Jira and Confluence tool calls